### PR TITLE
Adding stats for top 3 repos, most discussed PR, num PRs in Fellowship

### DIFF
--- a/data_collection/most_worked_on.py
+++ b/data_collection/most_worked_on.py
@@ -1,0 +1,48 @@
+import json
+import os
+import requests
+
+token = os.environ["GITHUB_API_TOKEN"]
+user = "kbanc"
+
+num_repos = 3
+num_lang = 2
+
+query = f"""query {{
+  user(login:"{user}"){{
+    contributionsCollection(from: "2020-06-01T07:00:00Z", to:"2020-08-24T07:00:00Z" ) {{
+			totalRepositoriesWithContributedPullRequests
+      totalPullRequestContributions
+      totalCommitContributions
+      totalIssueContributions
+      popularPullRequestContribution {{
+        pullRequest {{
+          merged
+          baseRepository{{
+            name
+            id
+						languages(first:1){{
+              nodes {{
+                name
+              }}
+            }}
+          }}
+        }}
+      }}
+      pullRequestContributionsByRepository(maxRepositories: {num_repos}){{
+        repository {{
+          name
+          languages(first: {num_lang}){{
+            nodes{{
+              name
+            }}
+          }}
+        }}
+      }}
+    }}
+  }}
+}}"""
+
+url = "https://api.github.com/graphql"
+r = requests.post(url, headers={"Authorization": f"token {token}"}, json={"query": query})
+print(r.text)

--- a/data_collection/most_worked_on.py
+++ b/data_collection/most_worked_on.py
@@ -17,8 +17,10 @@ query = f"""query {{
       totalIssueContributions
       popularPullRequestContribution {{
         pullRequest {{
+          title
+          url
           merged
-          baseRepository{{
+          repository{{
             name
             id
 						languages(first:1){{

--- a/data_collection/most_worked_on.py
+++ b/data_collection/most_worked_on.py
@@ -5,50 +5,55 @@ import requests
 token = os.environ["GITHUB_API_TOKEN"]
 user = "kbanc"
 
-num_repos = 3
+num_repos = 5
 num_lang = 2
 
-query = f"""query {{
-  user(login:"{user}"){{
-    contributionsCollection(from: "2020-06-01T07:00:00Z", to:"2020-08-24T07:00:00Z" ) {{
-			totalRepositoriesWithContributedPullRequests
-      totalPullRequestContributions
-      totalCommitContributions
-      totalIssueContributions
-      popularPullRequestContribution {{
-        pullRequest {{
-          title
-          url
-          merged
-          repository{{
+query = f"""
+  query {{
+    user(login:"{user}"){{
+      contributionsCollection(from: "2020-06-01T07:00:00Z", to:"2020-08-24T07:00:00Z" ) {{
+        totalRepositoriesWithContributedPullRequests
+        totalPullRequestContributions
+        totalCommitContributions
+        totalIssueContributions
+        popularPullRequestContribution {{
+          pullRequest {{
+            title
+            url
+            merged
+            repository{{
+              name
+              id
+              languages(first:1){{
+                nodes {{
+                  name
+                }}
+              }}
+            }}
+          }}
+        }}
+        pullRequestContributionsByRepository(maxRepositories: {num_repos}){{
+          repository {{
             name
-            id
-						languages(first:1){{
-              nodes {{
+            languages(first: {num_lang}){{
+              nodes{{
                 name
               }}
             }}
           }}
         }}
       }}
-      pullRequestContributionsByRepository(maxRepositories: {num_repos}){{
-        repository {{
-          name
-          languages(first: {num_lang}){{
-            nodes{{
-              name
-            }}
-          }}
-        }}
-      }}
     }}
-  }}
-}}"""
+  }}"""
 
 url = "https://api.github.com/graphql"
-r = requests.post(url, headers={"Authorization": f"token {token}"}, json={"query": query})
+r = requests.post(
+    url, headers={"Authorization": f"token {token}"}, json={"query": query})
 
 response = json.loads(r.text)
-print(f"Top {num_repos} contributed to repo:", response["data"]["user"]["contributionsCollection"]["pullRequestContributionsByRepository"])
-print("Total number of PRs during Fellowship (to any repo)", response["data"]["user"]["contributionsCollection"]["totalPullRequestContributions"])
-print("PR with the most discussion", response["data"]["user"]["contributionsCollection"]["popularPullRequestContribution"])
+print(f"Top {num_repos} contributed to repo:",
+      response["data"]["user"]["contributionsCollection"]["pullRequestContributionsByRepository"])
+print("Total number of PRs during Fellowship (to any repo)",
+      response["data"]["user"]["contributionsCollection"]["totalPullRequestContributions"])
+print("PR with the most discussion",
+      response["data"]["user"]["contributionsCollection"]["popularPullRequestContribution"])

--- a/data_collection/most_worked_on.py
+++ b/data_collection/most_worked_on.py
@@ -45,4 +45,8 @@ query = f"""query {{
 
 url = "https://api.github.com/graphql"
 r = requests.post(url, headers={"Authorization": f"token {token}"}, json={"query": query})
-print(r.text)
+
+response = json.loads(r.text)
+print(f"Top {num_repos} contributed to repo:", response["data"]["user"]["contributionsCollection"]["pullRequestContributionsByRepository"])
+print("Total number of PRs during Fellowship (to any repo)", response["data"]["user"]["contributionsCollection"]["totalPullRequestContributions"])
+print("PR with the most discussion", response["data"]["user"]["contributionsCollection"]["popularPullRequestContribution"])


### PR DESCRIPTION
Adding a query that returns information for a couple of desired statistics:

1. The number of PRs within the fellowship timeframe
2. The top three most popular repos and individual contributed to (the 'top' is defined by the [API](https://developer.github.com/v4/object/pullrequestcontributionsbyrepository/) and seems to make sense for my own profile)
3. Most 'popular' PR (aka the PR with the most amount of discussion)

Should help with #1 