### PR TITLE
Allow for cross origin requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask
 gunicorn
 flask_sqlalchemy
 psycopg2-binary
+flask-cors

--- a/web/factory.py
+++ b/web/factory.py
@@ -1,6 +1,7 @@
 import os
 
 from flask import Flask
+from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 
 
@@ -20,5 +21,6 @@ def create_app(init_db=False):
 
     from web.app import bp
     app.register_blueprint(bp)
+    CORS(app)
 
     return app


### PR DESCRIPTION
* Use `flask-cors` middleware 

This won't be used in production be is needed when calling the REST api from localhost.