### PR TITLE
web: Call API in frontend

### DIFF
--- a/web/templates/personal.html
+++ b/web/templates/personal.html
@@ -29,8 +29,10 @@
 
         const loadData = async() => {
             let teamData = await d3.json("{{ url_for('static',filename='dummy_data/group_members_by_teams.json') }}")
-            let globalData = await d3.json("{{ url_for('static',filename='dummy_data/global_stats.json') }}") // TODO: replace dummy data
-            let data = await d3.json("{{ url_for('static',filename='dummy_data/kai.json') }}") // TODO: replace dummy data
+            let globalData = await await fetch(`https://fellowship-class-profile.herokuapp.com/global_stats`)
+            globalData = await globalData.json();
+            let data = await fetch(`https://fellowship-class-profile.herokuapp.com/user_stats?username={{username}}`)
+            data = await data.json()
 
             // Fix data.
             data["num_contributions"] = data["num_commits"] // NOTE: num_commits in data is actually num_contributions


### PR DESCRIPTION
* Call `/user_stats` endpoint in JS
* `/login` and `/personal` now redirect appropriately depending on if logged in or not.
    * logged in -> `/login` -> redirect to `/personal`
    * logged out -> `/personal` -> redirect to `/login` 
* Small stylistic fixes to conform to python style standard (2 newlines lol)
* Fix `/logout` endpoint